### PR TITLE
remove ping method and relay on the gossip map value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/LNOpenMetrics/go-lnmetrics.reporter
 go 1.18
 
 require (
-	github.com/LNOpenMetrics/lnmetrics.utils v0.0.7
+	github.com/LNOpenMetrics/lnmetrics.utils v0.0.9
 	github.com/elastic/go-sysinfo v1.8.1
 	github.com/kinbiko/jsonassert v1.1.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/LNOpenMetrics/lnmetrics.utils v0.0.6 h1:fO6nTbMsLzJDEHRRfyS+QUSEzmyXH
 github.com/LNOpenMetrics/lnmetrics.utils v0.0.6/go.mod h1:6PC0XEUljl08AHdHdMQtR2tGJ1o9Jzg8yt7nioTnlE4=
 github.com/LNOpenMetrics/lnmetrics.utils v0.0.7 h1:iLorvC+QIkkiXztqwGe6lcNws3wiRhx38i/9y4Erf68=
 github.com/LNOpenMetrics/lnmetrics.utils v0.0.7/go.mod h1:6PC0XEUljl08AHdHdMQtR2tGJ1o9Jzg8yt7nioTnlE4=
+github.com/LNOpenMetrics/lnmetrics.utils v0.0.9 h1:1J3IR7BfJ/b495gMbckBs1a2MPWju/x3Vbhpp7BWriY=
+github.com/LNOpenMetrics/lnmetrics.utils v0.0.9/go.mod h1:oAoVWZLOyx78lI3rQihZ+QZpGwlZEJvwoVXyt4vcmoA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/plugin/metric_one_model.go
+++ b/internal/plugin/metric_one_model.go
@@ -2,8 +2,10 @@ package plugin
 
 import (
 	"encoding/json"
-	"github.com/LNOpenMetrics/go-lnmetrics.reporter/internal/db"
 	"strings"
+
+	"github.com/LNOpenMetrics/go-lnmetrics.reporter/internal/db"
+	"github.com/vincenzopalazzo/glightning/glightning"
 )
 
 // PaymentInfo Information about the Payment forward by the node
@@ -195,6 +197,8 @@ type MetricOne struct {
 
 	// Storage reference
 	Storage db.PluginDatabase `json:"-"`
+
+	PeerSnapshot map[string]*glightning.Peer
 }
 
 func (instance MetricOne) MarshalJSON() ([]byte, error) {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -85,7 +85,7 @@ func (plugin *MetricsPlugin) RegisterMethods() error {
 	return nil
 }
 
-//nolint
+// nolint
 func (plugin *MetricsPlugin) callUpdateOnMetric(metric Metric, msg *Msg) {
 	if err := metric.UpdateWithMsg(msg, plugin.Rpc); err != nil {
 		log.GetInstance().Errorf("Error during update metrics event: %s", err)

--- a/pkg/graphql/client.go
+++ b/pkg/graphql/client.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"golang.org/x/net/proxy"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -121,7 +121,7 @@ func (instance *Client) MakeRequest(query map[string]string) ([]*GraphQLResponse
 				log.GetInstance().Error(fmt.Sprintf("Error: %s", err))
 			}
 		}()
-		result, err := ioutil.ReadAll(response.Body)
+		result, err := io.ReadAll(response.Body)
 		if err != nil {
 			failure++
 			log.GetInstance().Error(fmt.Sprintf("error with the message \"%s\" during the request to endpoint %s", err, url))


### PR DESCRIPTION
With this PR I will remove ping method and relay on the gossip map value, because cln has some better method to do it internally, and from 0.12 we can rely on the connected filed that it is exposed inside the `listpeers` rpc command

This fix the bug that we see that the peer where we are connected are not online because the ping method fails badly