### PR TITLE
tests: add basic pytest for plugins repo

### DIFF
--- a/coffee.yaml
+++ b/coffee.yaml
@@ -1,7 +1,7 @@
 ---
 plugin:
   name: lnmetrics
-  version: 0.0.6-rc2
+  version: 0.0.6
   lang: go
   install: |
     make dep

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -x
+
+latest_release_tag=$(grep '^[[:space:]]*version:' coffee.yaml | awk '{print $2}' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+# Get the directory of the script
+script_dir=$(dirname -- "$(readlink -f -- "$0")")
+
+name="go-lnmetrics.reporter"
+repo="LNOpenMetrics"
+
+
+get_platform_file_end() {
+    machine=$(uname -m)
+    kernel=$(uname -s)
+
+    case $kernel in
+        Darwin)
+            echo 'darwin-amd64'
+            ;;
+        Linux)
+            case $machine in
+                x86_64)
+                    echo 'linux-amd64'
+                    ;;
+                armv7l)
+                    echo 'linux-arm'
+                    ;;
+                aarch64)
+                    echo 'linux-arm64'
+                    ;;
+                *)
+                    echo "No self-compiled binary found and unsupported release-architecture: $machine" >&2
+                    exit 1
+                    ;;
+            esac
+            ;;
+        *)
+            echo "No self-compiled binary found and unsupported OS: $kernel" >&2
+            exit 1
+            ;;
+    esac
+}
+platform_file_end=$(get_platform_file_end)
+archive_file="go-lnmetrics-$platform_file_end"
+
+github_url="https://github.com/$repo/$name/releases/download/v$latest_release_tag/$archive_file"
+
+
+# Download the archive using curl
+if ! curl -L "$github_url" -o "$script_dir/go-lnmetrics"; then
+    echo "Error downloading the file from $github_url" >&2
+    exit 1
+fi
+
+chmod u+x "$script_dir/go-lnmetrics"

--- a/tests/test_lnmetrics.py
+++ b/tests/test_lnmetrics.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+
+
+import os
+
+from pyln.testing.fixtures import *  # noqa: F403
+
+test_binary = os.path.join(os.path.dirname(__file__), "go-lnmetrics")
+
+
+def test_basic(node_factory):
+    node = node_factory.get_node(
+        options={
+            "plugin": test_binary,
+            "lnmetrics-urls": "https://api.lnmetrics.info/query",
+            "lnmetrics-noproxy": True,
+        }
+    )
+    # node.rpc.call("metric_one", {"start": "now"})
+    # node.rpc.call("raw-local-score")
+    # node.rpc.call("lnmetrics-force-update")
+    # node.rpc.call("lnmetrics-info")
+    # node.rpc.call("lnmetrics-clean")
+    assert False


### PR DESCRIPTION
As you know, we will require all plugins in the plugins repo to have atleast some basic test to show the users that this plugin is working. Unfortunately i don't quite understand what this plugin does and how to test it. All rpc methods i tried failed for different reasons. The one from the README, `metrics_one`, seems to be no longer in the code?! And the ones i found in the code did not work either. The `setup.sh` will be used by the plugins repo to get a release binary so we don't have to compile 100 plugins every CI run. If you could get the test working somehow that would be great! Otherwise @chrisguida will move this plugin into the archived section soon.